### PR TITLE
Provide id parameter in delete requests

### DIFF
--- a/src/things.rs
+++ b/src/things.rs
@@ -258,7 +258,7 @@ impl Thing {
 
         headers.insert("User-Agent", format!("ShredditClient/0.1").parse().unwrap());
 
-        let params = HashMap::from([("text", LOREM_IPSUM.to_string())]);
+        let params = HashMap::from([("id", self.fullname())]);
 
         client
             .post("https://oauth.reddit.com/api/del")


### PR DESCRIPTION
It looks like the params there were a placeholder, likely copied from a previous use. I updated it to use the fullname for the id param, as described by the api documentation here:

https://www.reddit.com/dev/api/#POST_api_del