### PR TITLE
Fix post deletion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "shreddit"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-stream",
  "chrono",

--- a/src/things.rs
+++ b/src/things.rs
@@ -291,11 +291,14 @@ impl Thing {
 
         sleep(Duration::from_secs(2)).await; // Reddit has a rate limit
 
-        self.edit(&client, &access_token, config.dry_run)
-            .await
-            .unwrap();
+        // Posts cannot be edited
+        if matches!(self, Thing::Comment { .. }) {
+            self.edit(&client, &access_token, config.dry_run)
+                .await
+                .unwrap();
 
-        sleep(Duration::from_secs(2)).await; // Reddit has a rate limit
+            sleep(Duration::from_secs(2)).await; // Reddit has a rate limit
+        }
 
         self.delete(client, access_token, config.dry_run).await;
     }


### PR DESCRIPTION
Shreddit was trying to edit posts before deleting, which is only possible with comments.

Fixes #14 