### PR TITLE
Check if comments were removed by moderator if edit fails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "shreddit"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-stream",
  "async-trait",


### PR DESCRIPTION
If editing a comment fails, it may be because a moderator removed the comment. This can be inferred if `can_gild` is set to `false` in the comment info.