### PR TITLE
Log unexpected access token response

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "shreddit"
-version = "0.6.1"
+version = "0.7.1"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shreddit"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 authors = ["Andrew Banchich <crates-io@andrew.banchi.ch>"]
 description = "Overwrite and delete your Reddit account history."

--- a/src/access_token.rs
+++ b/src/access_token.rs
@@ -1,6 +1,7 @@
 use crate::cli::Config;
 use reqwest::Client;
 use serde::Deserialize;
+use serde_json::Value;
 use std::collections::HashMap;
 
 pub async fn new_access_token(args: &Config, client: &Client) -> Result<String, String> {
@@ -24,6 +25,7 @@ pub async fn new_access_token(args: &Config, client: &Client) -> Result<String, 
     match res {
         AccessTokenResponse::Success { access_token } => Ok(access_token),
         AccessTokenResponse::Error { message, .. } => Err(message),
+        AccessTokenResponse::Unexpected(json) => Err(serde_json::to_string(&json).unwrap()),
     }
 }
 
@@ -38,4 +40,5 @@ enum AccessTokenResponse {
         error: String,
         message: String,
     },
+    Unexpected(Value),
 }

--- a/src/things/mod.rs
+++ b/src/things/mod.rs
@@ -48,6 +48,7 @@ static LOREM_IPSUM: &str = "Lorem ipsum dolor sit amet, consectetur adipiscing e
 
 #[derive(Debug)]
 pub enum ShredditError {
+    #[allow(dead_code)]
     RateLimited,
 }
 


### PR DESCRIPTION
If deserialization fails for known response structures from access token API, log response as JSON instead of panicking.