### PR TITLE
Rate limit update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+shreddit.env

--- a/src/things/comment.rs
+++ b/src/things/comment.rs
@@ -11,8 +11,7 @@ use futures_core::Stream;
 use reqwest::{header::HeaderMap, Client};
 use serde::Deserialize;
 use serde_json::Value;
-use std::{collections::HashMap, time::Duration};
-use tokio::time::sleep;
+use std::{collections::HashMap};
 use tracing::{debug, error, info, instrument};
 
 #[allow(unused)]
@@ -84,7 +83,7 @@ impl Shred for Comment {
             .await
             .unwrap();
 
-        sleep(Duration::from_secs(2)).await; // Reddit has a rate limit
+        self.prevent_rate_limit().await;
     }
 
     #[instrument(level = "debug", skip(client, access_token))]
@@ -170,7 +169,7 @@ impl Shred for Comment {
             },
         };
 
-        sleep(Duration::from_secs(2)).await; // Reddit has a rate limit
+        self.prevent_rate_limit().await;
     }
 }
 

--- a/src/things/comment.rs
+++ b/src/things/comment.rs
@@ -11,7 +11,7 @@ use futures_core::Stream;
 use reqwest::{header::HeaderMap, Client};
 use serde::Deserialize;
 use serde_json::Value;
-use std::{collections::HashMap};
+use std::collections::HashMap;
 use tracing::{debug, error, info, instrument};
 
 #[allow(unused)]

--- a/src/things/friend.rs
+++ b/src/things/friend.rs
@@ -41,7 +41,7 @@ impl Shred for Friend {
         } else {
             error!("Failed to delete");
         }
-        
+
         self.prevent_rate_limit().await;
     }
 }

--- a/src/things/friend.rs
+++ b/src/things/friend.rs
@@ -41,6 +41,8 @@ impl Shred for Friend {
         } else {
             error!("Failed to delete");
         }
+        
+        self.prevent_rate_limit().await;
     }
 }
 

--- a/src/things/mod.rs
+++ b/src/things/mod.rs
@@ -26,19 +26,20 @@ use async_trait::async_trait;
 // Reddit has a new rate limit as of 7/1/2023:
 // OAuth for authentication: 100 queries per minute per OAuth client id - sleep atleast 0.6s after every call ( 650 ms)
 // not using OAuth for authentication: 10 queries per minute - must sleep atleast 6s between calls ( 6500 ms)
-const SLEEP_TIME:u64 = 650;
-const SLEEP_DUR:Duration = Duration::from_millis(SLEEP_TIME);
-pub async fn prevent_rate_limit() { 
+const SLEEP_TIME: u64 = 650;
+const SLEEP_DUR: Duration = Duration::from_millis(SLEEP_TIME);
+pub async fn prevent_rate_limit() {
     debug!("Sleeping for {SLEEP_TIME}ms to prevent rate limiting.");
     sleep(SLEEP_DUR).await;
 }
-
 
 #[async_trait]
 pub trait Shred {
     async fn delete(&self, client: &Client, access_token: &str, config: &Config);
     async fn edit(&self, _client: &Client, _access_token: &str, _config: &Config) {}
-    async fn prevent_rate_limit(&self) { prevent_rate_limit().await; }
+    async fn prevent_rate_limit(&self) {
+        prevent_rate_limit().await;
+    }
     async fn shred(&self, client: &Client, access_token: &str, config: &Config) {
         self.edit(client, access_token, config).await;
         self.delete(client, access_token, config).await;

--- a/src/things/mod.rs
+++ b/src/things/mod.rs
@@ -29,7 +29,7 @@ use async_trait::async_trait;
 const SLEEP_TIME:u64 = 650;
 const SLEEP_DUR:Duration = Duration::from_millis(SLEEP_TIME);
 pub async fn prevent_rate_limit() { 
-    println!("\n -- Sleeping for {SLEEP_TIME}ms to prevent rate limiting...\n");
+    debug!("Sleeping for {SLEEP_TIME}ms to prevent rate limiting.");
     sleep(SLEEP_DUR).await;
 }
 

--- a/src/things/mod.rs
+++ b/src/things/mod.rs
@@ -18,7 +18,7 @@ use reqwest::Client;
 use serde::Deserialize;
 use std::{fmt::Debug, str::FromStr, time::Duration};
 use tokio::time::sleep;
-use tracing::instrument;
+use tracing::{debug, instrument};
 
 use crate::cli::Config;
 use async_trait::async_trait;

--- a/src/things/post.rs
+++ b/src/things/post.rs
@@ -10,7 +10,7 @@ use futures_core::Stream;
 use reqwest::{header::HeaderMap, Client};
 use serde::Deserialize;
 use serde_json::Value;
-use std::{collections::HashMap};
+use std::collections::HashMap;
 use tracing::{debug, error, info, instrument};
 
 #[derive(Debug, Deserialize)]

--- a/src/things/post.rs
+++ b/src/things/post.rs
@@ -10,8 +10,7 @@ use futures_core::Stream;
 use reqwest::{header::HeaderMap, Client};
 use serde::Deserialize;
 use serde_json::Value;
-use std::{collections::HashMap, time::Duration};
-use tokio::time::sleep;
+use std::{collections::HashMap};
 use tracing::{debug, error, info, instrument};
 
 #[derive(Debug, Deserialize)]
@@ -137,7 +136,7 @@ impl Shred for Post {
             .await
             .unwrap();
 
-        sleep(Duration::from_secs(2)).await; // Reddit has a rate limit
+        self.prevent_rate_limit().await;
     }
 }
 

--- a/src/things/saved_comment.rs
+++ b/src/things/saved_comment.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap};
+use std::collections::HashMap;
 
 use async_trait::async_trait;
 use reqwest::{header::HeaderMap, Client};

--- a/src/things/saved_comment.rs
+++ b/src/things/saved_comment.rs
@@ -1,9 +1,8 @@
-use std::{collections::HashMap, time::Duration};
+use std::{collections::HashMap};
 
 use async_trait::async_trait;
 use reqwest::{header::HeaderMap, Client};
 use serde::Deserialize;
-use tokio::time::sleep;
 use tracing::{error, info, instrument};
 
 use crate::{
@@ -65,6 +64,6 @@ impl Shred for SavedComment {
             error!("{:#?}", res.status());
         }
 
-        sleep(Duration::from_secs(2)).await; // Reddit has a rate limit
+        self.prevent_rate_limit().await;
     }
 }

--- a/src/things/saved_post.rs
+++ b/src/things/saved_post.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap};
+use std::collections::HashMap;
 
 use async_trait::async_trait;
 use reqwest::{header::HeaderMap, Client};

--- a/src/things/saved_post.rs
+++ b/src/things/saved_post.rs
@@ -1,9 +1,8 @@
-use std::{collections::HashMap, time::Duration};
+use std::{collections::HashMap};
 
 use async_trait::async_trait;
 use reqwest::{header::HeaderMap, Client};
 use serde::Deserialize;
-use tokio::time::sleep;
 use tracing::{error, info, instrument};
 
 use crate::{
@@ -65,6 +64,6 @@ impl Shred for SavedPost {
             error!("{:#?}", res.status());
         }
 
-        sleep(Duration::from_secs(2)).await; // Reddit has a rate limit
+        self.prevent_rate_limit().await;
     }
 }


### PR DESCRIPTION
Reduce the sleep timer from 2s to 650ms, in accordance with updated (higher) rate limits allowed as of 7/1. 
Replace all 'sleep()' timers with the new function that uses the calculated rate limit time.
- If implementing this change prior to 7/1, the variable must be changed to 1050ms to stay within the 60/min range in effect until 7/1
