### PR TITLE
Shred saved posts and comments with API

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,8 @@ use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, Env
 use crate::{
     sources::gdpr,
     things::{
-        comment, post, saved_post, Comment, Friend, Post, SavedComment, SavedPost, ThingType,
+        comment, post, saved_comment, saved_post, Comment, Friend, Post, SavedComment, SavedPost,
+        ThingType,
     },
 };
 
@@ -135,8 +136,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     }
 
                     ThingType::SavedComments => {
-                        error!("Shredding saved comments based on API is a TODO");
-                        todo!();
+                        let saved_comments =
+                            saved_comment::list(&client, &access_token, &config).await;
+                        pin_mut!(saved_comments);
+
+                        while let Some(saved_comment) = saved_comments.next().await {
+                            saved_comment.shred(&client, &access_token, &config).await;
+                        }
                     }
                 }
 

--- a/src/things/saved_comment.rs
+++ b/src/things/saved_comment.rs
@@ -1,9 +1,12 @@
 use std::collections::HashMap;
 
+use async_stream::stream;
 use async_trait::async_trait;
+use futures_core::Stream;
 use reqwest::{header::HeaderMap, Client};
 use serde::Deserialize;
-use tracing::{error, info, instrument};
+use serde_json::Value;
+use tracing::{debug, error, info, instrument};
 
 use crate::{
     cli::Config,
@@ -11,6 +14,13 @@ use crate::{
 };
 
 use super::Shred;
+
+#[derive(Debug, Deserialize)]
+pub struct SavedCommentData {
+    data: SavedComment,
+    #[allow(dead_code)]
+    kind: String,
+}
 
 #[allow(unused)]
 #[derive(Debug, Deserialize)]
@@ -25,6 +35,12 @@ impl Gdpr for SavedComment {
 
 impl Api for SavedComment {
     const TYPE_ID: &'static str = "t1";
+}
+
+impl SavedComment {
+    fn fullname(&self) -> String {
+        format!("{}_{}", Self::TYPE_ID, self.id)
+    }
 }
 
 #[async_trait]
@@ -66,4 +82,86 @@ impl Shred for SavedComment {
 
         self.prevent_rate_limit().await;
     }
+}
+
+/// https://www.reddit.com/dev/api/#GET_user_{username}_saved
+#[instrument(level = "info", skip_all)]
+pub async fn list(
+    client: &Client,
+    access_token: &str,
+    config: &Config,
+) -> impl Stream<Item = SavedComment> {
+    info!("Fetching posts...");
+
+    let client = client.clone();
+    let username = config.username.clone();
+    let user_agent = config.user_agent.clone();
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        "Authorization",
+        format!("Bearer {access_token}").parse().unwrap(),
+    );
+
+    headers.insert("User-Agent", user_agent.parse().unwrap());
+
+    stream! {
+    let mut last_seen = None;
+
+        loop {
+    let query_params = if let Some(last_seen) = last_seen {
+        format!("&after={last_seen}")
+    } else {
+        String::new()
+    };
+
+    let uri = format!("https://oauth.reddit.com/user/{username}/saved.json?&type=comments{query_params}");
+
+            let res: SavedCommentRes = client
+        .get(&uri)
+        .headers(headers.clone())
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+
+    match res {
+        SavedCommentRes::Success { data } => {
+
+    let results_len = data.children.len();
+
+    debug!("Page contained {results_len} results");
+
+    if results_len == 0 {
+                break;
+    } else {
+                last_seen = data.children.last().map(|t| t.data.fullname());
+    }
+
+    for comment in data.children {
+                yield comment.data;
+    }
+        }
+        SavedCommentRes::Error(e) => {
+    error!("{e:#?}");
+    break
+        }
+
+    }
+
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum SavedCommentRes {
+    Success { data: SavedCommentResData },
+    Error(Value),
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SavedCommentResData {
+    pub children: Vec<SavedCommentData>,
 }


### PR DESCRIPTION
Allow users to shred comments and posts through the OAuth API.

We can't really limit this in a reasonable manner though. They don't appear to track when a post is saved.