### PR TITLE
Added a skip-subreddits flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "shreddit"
-version = "0.9.1"
+version = "0.9.3"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ Options:
           The path of the directory of the unzipped GDPR export data. If set, `shreddit` will use the GDPR export folder instead of Reddit's APIs for discovering your data [env: SHREDDIT_GDPR_EXPORT_DIR=]
       --edit-only
           If specified, comments will only be edited, not deleted. - Requires gdpr_export [env: SHREDDIT_EDIT_ONLY=]
+      --skip-subreddits <SKIP_SUBREDDITS>
+          If specified, will skip these subreddits [env: SHREDDIT_SKIP_SUBREDDITS=]
   -h, --help
           Print help
   -V, --version
@@ -120,7 +122,7 @@ I'll be adding these as I go along. PRs are welcome!
 - [ ] Comment sorting
 - [ ] Clear vote - Remove your votes before deleting.
 - [x] Item - configure what kinds of items to delete (submissions, comments, etc.)
-- [ ] Subreddit whitelist - anything in given subreddits will not be deleted.
+- [x] Subreddit whitelist - anything in given subreddits will not be deleted.
 - [ ] Whitelist IDs - preserve specific posts by listing their IDs.
 - [ ] Preserve distinguished - Don't deleted distinguished comments.
 - [ ] Preserve gilded - Don't deleted gilded comments.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use crate::things::{ThingType, LOREM_IPSUM};
+use crate::things::{SubredditSet, ThingType, LOREM_IPSUM};
 use chrono::{DateTime, Utc};
 use clap::Parser;
 use std::path::PathBuf;
@@ -61,6 +61,10 @@ pub struct Config {
     /// If specified, comments will only be edited, not deleted. - Requires gdpr_export
     #[clap(long, env = "SHREDDIT_EDIT_ONLY")]
     pub edit_only: bool,
+
+    /// If specified, will skip these subreddits
+    #[clap(long, env = "SHREDDIT_SKIP_SUBREDDITS")]
+    pub skip_subreddits: Option<SubredditSet>,
 }
 
 impl Config {

--- a/src/things/mod.rs
+++ b/src/things/mod.rs
@@ -16,7 +16,7 @@ pub use saved_comment::*;
 use clap::ValueEnum;
 use reqwest::Client;
 use serde::Deserialize;
-use std::{fmt::Debug, str::FromStr, time::Duration};
+use std::{collections::HashSet, fmt::Debug, ops::Deref, str::FromStr, time::Duration};
 use tokio::time::sleep;
 use tracing::{debug, instrument};
 
@@ -86,5 +86,25 @@ impl FromStr for ThingType {
             "saved-comments" => Ok(Self::SavedComments),
             _ => Err("Invalid type"),
         }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SubredditSet(HashSet<String>);
+
+impl std::convert::From<&str> for SubredditSet {
+    fn from(s: &str) -> Self {
+        let mut subreddits = HashSet::<String>::new();
+        s.split(',').for_each(|f| {
+            subreddits.insert(f.to_owned());
+        });
+        SubredditSet(subreddits)
+    }
+}
+
+impl Deref for SubredditSet {
+    type Target = HashSet<String>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }

--- a/src/things/saved_comment.rs
+++ b/src/things/saved_comment.rs
@@ -26,6 +26,7 @@ pub struct SavedCommentData {
 #[derive(Debug, Deserialize)]
 pub struct SavedComment {
     id: String,
+    subreddit: String,
     permalink: String,
 }
 
@@ -49,9 +50,9 @@ impl Shred for SavedComment {
     async fn delete(&self, client: &Client, access_token: &str, config: &Config) {
         info!("Deleting...");
 
-        // if self.should_skip(config) {
-        //     return;
-        // }
+        if self.should_skip(config) {
+            return;
+        }
 
         if config.should_prevent_deletion() {
             return;
@@ -81,6 +82,18 @@ impl Shred for SavedComment {
         }
 
         self.prevent_rate_limit().await;
+    }
+}
+
+impl SavedComment {
+    fn should_skip(&self, config: &Config) -> bool {
+        if let Some(skip_subreddits) = &config.skip_subreddits {
+            if skip_subreddits.contains(&self.subreddit) {
+                debug!("Skipping due to `skip_subreddits` filter");
+                return true;
+            }
+        }
+        false
     }
 }
 


### PR DESCRIPTION
Added a new flag *skip-subreddits* allowing users to skip deleting any of the "things" from the given subreddits.
Example: 
`shreddit  --skip-subreddits rust,swift`

Note, I didn't have a chance to test with GDPR data (just requested it) so I assumed the model would be the same (would have *subreddit* param).