### PR TITLE
Modify config so SHREDDIT_BEFORE supports duration notation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -732,6 +732,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -770,6 +779,17 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "parse_datetime"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bffd1156cebf13f681d7769924d3edfb9d9d71ba206a8d8e8e7eb9df4f4b1e7"
+dependencies = [
+ "chrono",
+ "nom",
+ "regex",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -1132,6 +1152,7 @@ dependencies = [
  "dotenvy",
  "futures-core",
  "futures-util",
+ "parse_datetime",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1063,18 +1063,18 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,4 @@ serde_json = "1.0.139"
 tokio = { version = "1.43.0", features = ["rt", "macros"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.19", features = ["fmt", "env-filter"] }
+parse_duration = "2.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,4 +25,4 @@ serde_json = "1.0.139"
 tokio = { version = "1.43.0", features = ["rt", "macros"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.19", features = ["fmt", "env-filter"] }
-parse_duration = "2.1.1"
+parse_datetime = "0.8.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ reqwest = { version = "0.12.12", default-features = false, features = [
     "json",
     "rustls-tls",
 ] }
-serde = { version = "1.0.164", features = ["derive"] }
+serde = { version = "1.0.218", features = ["derive"] }
 serde_json = "1.0.139"
 tokio = { version = "1.43.0", features = ["rt", "macros"] }
 tracing = "0.1.37"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,8 +1,8 @@
 use crate::things::{CommentIdSet, PostIdSet, SubredditSet, ThingType, LOREM_IPSUM};
 use chrono::{DateTime, Utc};
 use clap::Parser;
-use std::path::PathBuf;
 use parse_datetime::parse_datetime;
+use std::path::PathBuf;
 use tracing::{debug, warn};
 
 /// Parses `SHREDDIT_BEFORE` to support:
@@ -21,8 +21,11 @@ fn parse_before(input: &str) -> Result<DateTime<Utc>, String> {
                 let duration = datetime_utc - Utc::now();
                 // Subtract the duration from the current time to get the target timestamp
                 Ok(Utc::now() - duration)
-            },
-            Err(_) => Err(format!("Invalid duration format for SHREDDIT_BEFORE: {}", input)),
+            }
+            Err(_) => Err(format!(
+                "Invalid duration format for SHREDDIT_BEFORE: {}",
+                input
+            )),
         }
     } else {
         // Try to parse as an absolute timestamp
@@ -31,8 +34,11 @@ fn parse_before(input: &str) -> Result<DateTime<Utc>, String> {
                 // Convert the parsed `DateTime<FixedOffset>` to `DateTime<Utc>`
                 let utc_timestamp = datetime.with_timezone(&Utc);
                 Ok(utc_timestamp)
-            },
-            Err(_) => Err(format!("Invalid timestamp format for SHREDDIT_BEFORE: {}", input)),
+            }
+            Err(_) => Err(format!(
+                "Invalid timestamp format for SHREDDIT_BEFORE: {}",
+                input
+            )),
         }
     }
 }


### PR DESCRIPTION
Allows you to specify a duration notation (ie: '-30d', '-2w', '-5h') or a date in the SHREDDIT_BEFORE field.  This enables you to run this at any time and have it delete any comments more than say 30 days old (-30d)