### PR TITLE
docs: Update usage output to document valid arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This brings several benefits:
 
 - You don't need to have Python or anything else installed.
 - Instead of having `shreddit.yml` and `praw.ini` config files, all configuration can be done through CLI commands
-with environment variables as default fallbacks.
+  with environment variables as default fallbacks.
 
 # Installation
 
@@ -62,7 +62,7 @@ Options:
   -p, --password <PASSWORD>
           Your Reddit password [env: SHREDDIT_PASSWORD=]
       --client-id <CLIENT_ID>
-          To create client credentials, you need to navigate to `https://old.reddit.com/prefs/apps/`, click `create another app...` and fill out the form. Select the `script` type, and set `redirect uri` as `http://localhost:8080` [env: SHREDDIT_CLIENT_ID=]
+          To create client credentials, you need to navigate to `https://www.reddit.com/prefs/apps/`, click `create another app...` and fill out the form. Select the `script` type, and set `redirect uri` as `http://localhost:8080` [env: SHREDDIT_CLIENT_ID=]
       --client-secret <CLIENT_SECRET>
           The client secret from when you created client credentials [env: SHREDDIT_CLIENT_SECRET=]
       --dry-run
@@ -70,11 +70,9 @@ Options:
       --thing-types <THING_TYPES>
           What "things" you want to delete [env: SHREDDIT_THING_TYPES=] [default: posts comments] [possible values: posts, comments, friends, saved-posts, saved-comments]
       --before <BEFORE>
-          [env: SHREDDIT_BEFORE=] [default: "2025-03-03 07:24:13.673800 UTC"]
-          Don't alter things that were created before this date.
+          Delete items before a specific date or duration (e.g., `-30 days`) [env: SHREDDIT_BEFORE=]
       --after <AFTER>
-          Don't alter things that were created after this date.
-          [env: SHREDDIT_AFTER=] [2023-06-25 14:42:43.828192320 UTC]
+          Delete items after a specific date or duration (e.g., `-30 days`) [env: SHREDDIT_AFTER=]
       --max-score <MAX_SCORE>
           [env: SHREDDIT_MAX_SCORE=]
   -r, --replacement-comment <REPLACEMENT_COMMENT>
@@ -86,13 +84,13 @@ Options:
       --edit-only
           If specified, comments will only be edited, not deleted. - Requires gdpr_export [env: SHREDDIT_EDIT_ONLY=]
       --skip-subreddits <SKIP_SUBREDDITS>
-          If specified, will skip these subreddits [env: SHREDDIT_SKIP_SUBREDDITS=]
+          If specified, will skip these subreddits. Comma-separated. - Case-sensitive [env: SHREDDIT_SKIP_SUBREDDITS=]
       --skip-comment-ids <SKIP_COMMENT_IDS>
-          If specified, will skip comments and saved comments with listed ids [env: SHREDDIT_SKIP_COMMENT_IDS=]
+          If specified, will skip comments and saved comments with listed ids. - Comma-separated [env: SHREDDIT_SKIP_COMMENT_IDS=]
       --skip-post-ids <SKIP_POST_IDS>
-          If specified, will skip posts and saved posts with listed ids [env: SHREDDIT_SKIP_POST_IDS=]
+          If specified, will skip posts and saved posts with listed ids. - Comma-separated [env: SHREDDIT_SKIP_POST_IDS=]
       --only-subreddits <ONLY_SUBREDDITS>
-          If specified, only posts, comments, saved posts, and saved comments in the specified subreddits will be deleted [env: SHREDDIT_ONLY_SUBREDDITS=]
+          If specified, only posts, comments, saved posts, and saved comments in the specified subreddits will be deleted. - Comma-separated. Case-sensitive [env: SHREDDIT_ONLY_SUBREDDITS=]
   -h, --help
           Print help
   -V, --version

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -49,11 +49,11 @@ pub struct Config {
     #[clap(long, env = "SHREDDIT_THING_TYPES", default_values = &["posts", "comments"], value_delimiter = ',')]
     pub thing_types: Vec<ThingType>,
 
-    /// Delete items before a specific date or duration (e.g., `-30d`).
+    /// Delete items before a specific date or duration (e.g., `-30 days`).
     #[clap(long, env = "SHREDDIT_BEFORE", value_parser = parse_relative)]
     pub before: Option<DateTime<Utc>>,
 
-    /// Delete items after a specific date or duration (e.g., `-30d`).
+    /// Delete items after a specific date or duration (e.g., `-30 days`).
     #[clap(long, env = "SHREDDIT_AFTER", value_parser = parse_relative)]
     pub after: Option<DateTime<Utc>>,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -82,19 +82,19 @@ pub struct Config {
     #[clap(long, env = "SHREDDIT_EDIT_ONLY")]
     pub edit_only: bool,
 
-    /// If specified, will skip these subreddits
+    /// If specified, will skip these subreddits. Comma-separated. - Case-sensitive
     #[clap(long, env = "SHREDDIT_SKIP_SUBREDDITS")]
     pub skip_subreddits: Option<SubredditSet>,
 
-    /// If specified, will skip comments and saved comments with listed ids
+    /// If specified, will skip comments and saved comments with listed ids. - Comma-separated
     #[clap(long, env = "SHREDDIT_SKIP_COMMENT_IDS")]
     pub skip_comment_ids: Option<CommentIdSet>,
 
-    /// If specified, will skip posts and saved posts with listed ids
+    /// If specified, will skip posts and saved posts with listed ids. - Comma-separated
     #[clap(long, env = "SHREDDIT_SKIP_POST_IDS")]
     pub skip_post_ids: Option<PostIdSet>,
 
-    /// If specified, only posts, comments, saved posts, and saved comments in the specified subreddits will be deleted
+    /// If specified, only posts, comments, saved posts, and saved comments in the specified subreddits will be deleted. - Comma-separated. Case-sensitive
     #[clap(
         long,
         env = "SHREDDIT_ONLY_SUBREDDITS",


### PR DESCRIPTION
- Corrects examples for `before` and `after` arguments
- Indicates where a comma-separated value is needed
- Hint when a argument is case-sensitive

Fixes #175 