### PR TITLE
fix: use consistent sorting to ensure all comments captured

### DIFF
--- a/src/things/comment.rs
+++ b/src/things/comment.rs
@@ -322,7 +322,7 @@ pub async fn list(client: &Client, config: &Config) -> impl Stream<Item = Commen
     let query_params = if let Some(last_seen) = last_seen {
         format!("?after={last_seen}&limit=100")
     } else {
-        "?sort=top&limit=100".to_string()
+        "?limit=100".to_string()
     };
 
     let uri = format!("https://reddit.com/user/{username}/comments.json{query_params}");


### PR DESCRIPTION
Thanks for the awesome tool! I ran into an issue that I wanted to submit a fix for.

In my case, I started out using `--only-subreddits <sub1>` to remove comments selectively. But I noticed that the script quickly finished without considering any of the comments in `<sub1>`. I think this is because the comments are initially retrieved sorted by `top`, then `last_seen` is set based on the final `top` comment returned, but then `last_seen` is used _without_ sorting by `top` (implicitly sorting by `new`). So we need to either sort by `top` both times, or never -- I chose never because it mirrors the default sorting.