### PR TITLE
fix: use oauth for listing posts/comments

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -104,7 +104,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
                 match thing_type {
                     ThingType::Posts => {
-                        let posts = post::list(&client, &config).await;
+                        let posts = post::list(&client, &access_token, &config).await;
                         pin_mut!(posts);
 
                         while let Some(post) = posts.next().await {
@@ -113,7 +113,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     }
 
                     ThingType::Comments => {
-                        let comments = comment::list(&client, &config).await;
+                        let comments = comment::list(&client, &access_token, &config).await;
                         pin_mut!(comments);
 
                         while let Some(comment) = comments.next().await {


### PR DESCRIPTION
- add oauth authentication to `post::list()` and `comment::list()`
  - this is consistent with how saved posts/comments were already implemented
- fixes #214