### PR TITLE
feat(release): Add support for macOS ARM64 (Apple Silicon)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,8 +43,11 @@ jobs:
             os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
           - platform: mac-x86_64
-            os: macos-13
+            os: macos-latest
             target: x86_64-apple-darwin
+          - platform: mac-arm64
+            os: macos-latest
+            target: aarch64-apple-darwin
           - platform: windows
             os: windows-latest
             target: x86_64-pc-windows-gnu


### PR DESCRIPTION
- Add support for macOS ARM64 (Apple Silicon)
- Update macOS runner from deprecated `macos-13` to `macos-latest` ([deprecation notice](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/))

```
λ uname -m
arm64

λ rustc --version --verbose | grep host
host: aarch64-apple-darwin

λ rustc --print target-list | grep apple-darwin
aarch64-apple-darwin
arm64e-apple-darwin
i686-apple-darwin
x86_64-apple-darwin
x86_64h-apple-darwin
```